### PR TITLE
Fix cached prepared statements retain old values if passed nil in mysqloolib

### DIFF
--- a/lua/mysqloolib.lua
+++ b/lua/mysqloolib.lua
@@ -150,6 +150,8 @@ function db:RunQuery(str, callback, ...)
 end
 
 local function setPreparedQueryArguments(query, values)
+	query:clearParameters()
+
 	if (type(values) != "table") then
 		values = { values }
 	end


### PR DESCRIPTION
If you run the same query with `db:PrepareQuery(sqlString, params)` with non-nil values and then again with nil ones, it will run with previous value instead of db native NULLs. This PR fixes that 