### PR TITLE
fix: correct occured to occurred typo in user-facing error messages (4 files)

### DIFF
--- a/Examples/multi_parameters.lua
+++ b/Examples/multi_parameters.lua
@@ -6,7 +6,7 @@ function preparedQuery:onSuccess(data)
 end
 
 function preparedQuery:onError(err)
-	print("An error occured while executing the query: " .. err)
+	print("An error occurred while executing the query: " .. err)
 end
 
 preparedQuery:setString(1, "STEAM_0:0:123456")

--- a/Examples/multi_results.lua
+++ b/Examples/multi_results.lua
@@ -12,7 +12,7 @@ function query:onSuccess(data)
 end
 
 function query:onError(err)
-	print("An error occured while executing the query: " .. err)
+	print("An error occurred while executing the query: " .. err)
 end
 
 query:start()

--- a/Examples/prepared_query.lua
+++ b/Examples/prepared_query.lua
@@ -6,7 +6,7 @@ function preparedQuery:onSuccess(data)
 end
 
 function preparedQuery:onError(err)
-	print("An error occured while executing the query: " .. err)
+	print("An error occurred while executing the query: " .. err)
 end
 
 preparedQuery:setString(1, "STEAM_0:0:123456")

--- a/Examples/query.lua
+++ b/Examples/query.lua
@@ -9,7 +9,7 @@ function query:onSuccess(data)
 end
 
 function query:onError(err)
-	print("An error occured while executing the query: " .. err)
+	print("An error occurred while executing the query: " .. err)
 end
 
 query:start()


### PR DESCRIPTION
## Summary
Fixes a typo in user-facing error messages shown to users when SQL queries fail.

**Files changed (4 instances):**
- Examples/query.lua:12
- Examples/multi_results.lua:15
- Examples/prepared_query.lua:9
- Examples/multi_parameters.lua:9

All changed: `An error occured while executing the query: {err}` → `An error occurred...`

## Testing
- Verified locally: 4 files, 4 insertions(+), 4 deletions(-)
- Surgical typo correction only